### PR TITLE
Restrict the length of verify code.

### DIFF
--- a/Yep/ViewControllers/Login/LoginVerifyMobileViewController.swift
+++ b/Yep/ViewControllers/Login/LoginVerifyMobileViewController.swift
@@ -231,5 +231,14 @@ extension LoginVerifyMobileViewController: UITextFieldDelegate {
         return true
     }
     */
+    
+    func textField(textField: UITextField, shouldChangeCharactersInRange range: NSRange, replacementString string: String) -> Bool {
+        let currentCharacterCount = textField.text?.characters.count ?? 0
+        if range.length + range.location > currentCharacterCount {
+            return false
+        }
+        let newLength = currentCharacterCount + string.characters.count - range.length
+        return newLength <= YepConfig.verifyCodeLength()
+    }
 }
 

--- a/Yep/ViewControllers/Register/RegisterVerifyMobileViewController.swift
+++ b/Yep/ViewControllers/Register/RegisterVerifyMobileViewController.swift
@@ -225,5 +225,14 @@ extension RegisterVerifyMobileViewController: UITextFieldDelegate {
         return true
     }
     */
+    
+    func textField(textField: UITextField, shouldChangeCharactersInRange range: NSRange, replacementString string: String) -> Bool {
+        let currentCharacterCount = textField.text?.characters.count ?? 0
+        if range.length + range.location > currentCharacterCount {
+            return false
+        }
+        let newLength = currentCharacterCount + string.characters.count - range.length
+        return newLength <= YepConfig.verifyCodeLength()
+    }
 }
 


### PR DESCRIPTION
If user type in a false verify code, Yep will show a false alert. But
after tapped “OK” button, user can continue to entry digits. Now, after
implement this method, user cannot entry more than 4 digits which is
configured in “YepConfig.verifyCodeLength()”.
