### PR TITLE
more swifty to update Set

### DIFF
--- a/YepKit/UserDefaults/YepUserDefaults.swift
+++ b/YepKit/UserDefaults/YepUserDefaults.swift
@@ -73,10 +73,11 @@ final public class Listenable<T> {
     var listenerSet = Set<Listener<T>>()
 
     public func bindListener(_ name: String, action: @escaping Listener<T>.Action) {
-        removeListenerWithName(name)
-
         let listener = Listener(name: name, action: action)
         listenerSet.insert(listener)
+        
+        // @available(swift, obsoleted: 3.0)
+        // listenerSet.insert(listener)
     }
 
     public func bindAndFireListener(_ name: String, action: @escaping Listener<T>.Action) {


### PR DESCRIPTION
A look through the API docs revealed a new function called update(with newMember:Element) that behaves like the old insert - adds an element to the Set if not present, otherwise updates the element.